### PR TITLE
authorizer: add package of useful authorization functions

### DIFF
--- a/authorizer/map.go
+++ b/authorizer/map.go
@@ -1,0 +1,53 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package authorizer implements access control helpers for tailsql.
+package authorizer
+
+import (
+	"fmt"
+	"log"
+
+	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/types/logger"
+)
+
+// A Map maps source labels to lists of usernames who are granted access to
+// issue queries against that source.
+type Map map[string][]string
+
+// Authorize returns an authorization function suitable for tailsql.Options.
+//
+// If a source label is not present in the map, all logged-in users are
+// permitted to query the source.  If a source label is present in the map,
+// only logged-in users in the list are permitted to query the source.  Tagged
+// nodes are not permitted to query any source.
+//
+// If logf == nil, logs are sent to log.Printf.
+func (m Map) Authorize(logf logger.Logf) func(string, *apitype.WhoIsResponse) error {
+	if logf == nil {
+		logf = log.Printf
+	}
+	return func(src string, who *apitype.WhoIsResponse) (err error) {
+		caller := who.UserProfile.LoginName
+		if who.Node.IsTagged() {
+			caller = who.Node.Name
+		}
+		defer func() {
+			logf("[tailsql] auth src=%q who=%q err=%v", src, caller, err)
+		}()
+		if who.Node.IsTagged() {
+			return fmt.Errorf("tagged nodes cannot query %q", src)
+		}
+		users, ok := m[src]
+		if !ok {
+			return nil // no restriction on this source
+		}
+		for _, u := range users {
+			if u == caller {
+				return nil // this user is permitted access
+			}
+		}
+		return fmt.Errorf("not authorized for access to %q", src)
+	}
+}

--- a/authorizer/peercaps.go
+++ b/authorizer/peercaps.go
@@ -1,0 +1,53 @@
+// Copyright (c) Tailscale Inc & AUTHORS
+// SPDX-License-Identifier: BSD-3-Clause
+
+package authorizer
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"tailscale.com/client/tailscale/apitype"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/logger"
+)
+
+// tailsqlCap is the default name of the tailsql capability.
+const tailsqlCap = "https://tailscale.com/cap/tailsql"
+
+// PeerCaps returns an authorization function that uses peer capabilities from
+// the tailnet to check access for query sources.
+// If logf == nil, logs are sent to log.Printf.
+//
+// TODO(creachadair): As of 10-Aug-2023 peer capabilities are an experimental
+// feature that only works on tailnets where enaled.
+func PeerCaps(logf logger.Logf) func(string, *apitype.WhoIsResponse) error {
+	if logf == nil {
+		logf = log.Printf
+	}
+	return func(dataSrc string, who *apitype.WhoIsResponse) (err error) {
+		caller := who.UserProfile.LoginName
+		if who.Node.IsTagged() {
+			caller = who.Node.Name
+		}
+		defer func() {
+			logf("[tailsql] auth src=%q who=%q err=%v", dataSrc, caller, err)
+		}()
+		type rule struct {
+			DataSrc []string `json:"src"`
+		}
+		rules, err := tailcfg.UnmarshalCapJSON[rule](who.CapMap, tailsqlCap)
+		if err != nil || len(rules) == 0 {
+			return errors.New("not authorized for access tailsql")
+		}
+		for _, rule := range rules {
+			for _, s := range rule.DataSrc {
+				if s == "*" || s == dataSrc {
+					return nil
+				}
+			}
+		}
+		return fmt.Errorf("not authorized for access to %q", dataSrc)
+	}
+}

--- a/server/tailsql/internal_test.go
+++ b/server/tailsql/internal_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tailscale/tailsql/authorizer"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
 )
@@ -76,6 +77,7 @@ func TestOptions(t *testing.T) {
 	if diff := cmp.Diff(want, opts); diff != "" {
 		t.Errorf("Parsed options (-want, +got)\n%s", diff)
 	}
+	opts.Authorize = authorizer.PeerCaps(nil)
 
 	// Test that we can populate options from the config.
 	t.Run("Options", func(t *testing.T) {

--- a/server/tailsql/tailsql.go
+++ b/server/tailsql/tailsql.go
@@ -52,7 +52,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -115,10 +114,6 @@ func NewServer(opts Options) (*Server, error) {
 	if opts.Metrics != nil {
 		addMetrics(opts.Metrics)
 	}
-	logf := opts.Logf
-	if logf == nil {
-		logf = log.Printf
-	}
 	return &Server{
 		lc:        opts.LocalClient,
 		state:     state,
@@ -127,7 +122,7 @@ func NewServer(opts Options) (*Server, error) {
 		rules:     opts.UIRewriteRules,
 		authorize: opts.authorize(),
 		qtimeout:  opts.QueryTimeout.Duration(),
-		logf:      logf,
+		logf:      opts.logf(),
 		dbs:       dbs,
 	}, nil
 }

--- a/server/tailsql/tailsql_test.go
+++ b/server/tailsql/tailsql_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tailscale/tailsql/authorizer"
 	"github.com/tailscale/tailsql/server/tailsql"
 	"github.com/tailscale/tailsql/uirules"
 	"golang.org/x/exp/slices"
@@ -113,6 +114,7 @@ func TestServer(t *testing.T) {
 			{Anchor: testAnchor, URL: testURL},
 		},
 		UIRewriteRules: testUIRules,
+		Authorize:      authorizer.PeerCaps(nil),
 	})
 	if err != nil {
 		t.Fatalf("NewServer: unexpected error: %v", err)


### PR DESCRIPTION
These functions plug into the tailsql.Options, allowing the caller to replace
the default behaviour rather than hard-coding a dependency on peerCaps.
Update usage so that the functionality does not change (for now).
