### PR TITLE
server/tailsql: add a query context decorator

### DIFF
--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -82,6 +82,12 @@ type Options struct {
 	// by the rule replaces the original string.
 	UIRewriteRules []UIRewriteRule `json:"-"`
 
+	// If non-nil, this function is called to annotate ctx before passing it in
+	// to a database query for the given source. If the callback is nil, or if
+	// it returns nil, ctx is used unmodified. Otherwise the returned value
+	// replaces ctx in the query.
+	QueryContext func(ctx context.Context, src, query string) context.Context `json:"-"`
+
 	// If non-nil, send logs to this logger. If nil, use log.Printf.
 	Logf logger.Logf `json:"-"`
 }


### PR DESCRIPTION
Our cgo sqlite driver takes some options on the request context.  To give us a
way to plumb those in, add an optional callback.

I recommend viewing the diff without whitespace, as most of the change is just
indentation at the point of the callback.
