### PR TITLE
server: plumb tailsql.Query instead of separate strings

### DIFF
--- a/server/tailsql/internal_test.go
+++ b/server/tailsql/internal_test.go
@@ -13,7 +13,7 @@ import (
 	"tailscale.com/tailcfg"
 )
 
-func TestCheckQuery(t *testing.T) {
+func TestCheckQuerySyntax(t *testing.T) {
 	tests := []struct {
 		query string
 		ok    bool
@@ -37,7 +37,7 @@ func TestCheckQuery(t *testing.T) {
         as demon_spawn;`, false},
 	}
 	for _, tc := range tests {
-		err := checkQuery(tc.query)
+		err := checkQuerySyntax(tc.query)
 		if tc.ok && err != nil {
 			t.Errorf("Query %q: unexpected error: %v", tc.query, err)
 		} else if !tc.ok && err == nil {

--- a/server/tailsql/utils.go
+++ b/server/tailsql/utils.go
@@ -212,13 +212,13 @@ func errorCode(err error) int {
 	return http.StatusInternalServerError
 }
 
-// checkQuery reports whether query is safe to send to the database.
+// checkQuerySyntax reports whether query is safe to send to the database.
 //
 // A read-only SQLite database will correctly report errors for operations that
 // modify the database or its schema if it is opened read-only. However, the
 // ATTACH and DETACH verbs modify only the connection, permitting the caller to
 // mention any database accessible from the filesystem.
-func checkQuery(query string) error {
+func checkQuerySyntax(query string) error {
 	for _, tok := range sqlTokens(query) {
 		switch tok {
 		case "ATTACH", "DETACH", "TEMP", "TEMPORARY":


### PR DESCRIPTION
A followup to #22, replacing the explicit string arguments in the server
plumbing with the new query carrier type.
