### PR TITLE
server: add support for fully-programmatic data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ opts := tailsql.Options{
 }
 ```
 
-Any number of sources can be configured this way. It is also possible to add new data sources dynamically at runtime using the `SetDB` method of the server. It is _not_ currently possible to remove data sources once added, however.
+Any number of sources can be configured this way. It is also possible to add new data sources dynamically at runtime using the `SetDB` and `SetSource` methods of the server. It is _not_ currently possible to remove data sources once added, however.
 
 ### Tailscale Integration
 

--- a/server/tailsql/internal_test.go
+++ b/server/tailsql/internal_test.go
@@ -4,6 +4,7 @@
 package tailsql
 
 import (
+	"database/sql"
 	"os"
 	"testing"
 
@@ -11,6 +12,12 @@ import (
 	"github.com/tailscale/tailsql/authorizer"
 	"tailscale.com/client/tailscale/apitype"
 	"tailscale.com/tailcfg"
+)
+
+// Interface satisfaction checks.
+var (
+	_ Queryable = sqlDB{}
+	_ RowSet    = (*sql.Rows)(nil)
 )
 
 func TestCheckQuerySyntax(t *testing.T) {

--- a/server/tailsql/local.go
+++ b/server/tailsql/local.go
@@ -95,7 +95,7 @@ func (s *localState) LogQuery(ctx context.Context, user string, q Query, elapsed
 }
 
 // Query satisfies part of the Queryable interface. It supports only read queries.
-func (s *localState) Query(ctx context.Context, query string) (RowSet, error) {
+func (s *localState) Query(ctx context.Context, query string, params ...any) (RowSet, error) {
 	s.txmu.RLock()
 	defer s.txmu.RUnlock()
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
@@ -103,7 +103,7 @@ func (s *localState) Query(ctx context.Context, query string) (RowSet, error) {
 		return nil, err
 	}
 	defer tx.Rollback()
-	return tx.QueryContext(ctx, query)
+	return tx.QueryContext(ctx, query, params...)
 }
 
 // Close satisfies part of the Queryable interface.  For this database the

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -610,3 +610,36 @@ func DefaultCheckQuery(q Query) (Query, error) {
 	}
 	return q, nil
 }
+
+// Queryable is the interface used to issue SQL queries to a database.
+type Queryable interface {
+	// Query issues the specified SQL query in a transaction and returns the
+	// matching result set, if any.
+	Query(ctx context.Context, sql string) (RowSet, error)
+
+	// Close closes the database.
+	Close() error
+}
+
+// A RowSet is a sequence of rows reported by a query. It is a subset of the
+// interface exposed by [database/sql.Rows], and the implementation must
+// provide the same semantics for each of these methods.
+type RowSet interface {
+	// Columns reports the names of the columns requested by the query.
+	Columns() ([]string, error)
+
+	// Close closes the row set, preventing further enumeration.
+	Close() error
+
+	// Err returns the error, if any, that was encountered during iteration.
+	Err() error
+
+	// Next prepares the next result row for reading by the Scan method, and
+	// reports true if this was successful or false if there was an error or no
+	// more rows are available.
+	Next() bool
+
+	// Scan copies the columns of the currently-selected row into the values
+	// pointed to by its arguments.
+	Scan(...any) error
+}

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -119,6 +119,19 @@ func (o Options) openSources(store *setec.Store) ([]*dbHandle, error) {
 			spec.Label = "(unidentified database)"
 		}
 
+		// Case 1: A programmatic source.
+		if spec.DB != nil {
+			srcs[i] = &dbHandle{
+				src:   spec.Source,
+				label: spec.Label,
+				named: spec.Named,
+				db:    spec.DB,
+			}
+			continue
+		}
+
+		// Case 2: A database managed by database/sql.
+		//
 		// Resolve the connection string.
 		var connString string
 		var w setec.Watcher
@@ -138,6 +151,7 @@ func (o Options) openSources(store *setec.Store) ([]*dbHandle, error) {
 			panic("unexpected: no connection source is defined after validation")
 		}
 
+		// Open and ping the database to ensure it is approximately usable.
 		db, err := openAndPing(spec.Driver, connString)
 		if err != nil {
 			return nil, err

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -25,15 +25,18 @@ import (
 )
 
 // Options describes settings for a Server.
+//
+// The fields marked as "tsnet" are not used directly by tailsql, but are
+// provided for the convenience of a main program that wants to run the server
+// under tsnet.
 type Options struct {
-	// The tailnet hostname the server should run on (required).
+	// The tailnet hostname the server should run on (tsnet).
 	Hostname string `json:"hostname,omitempty"`
 
-	// The directory for tailscale state and configurations (optional).
-	// If omitted or empty, the default location is used.
+	// The directory for tailscale state and configurations (tsnet).
 	StateDir string `json:"stateDir,omitempty"`
 
-	// If true, serve HTTPS instead of HTTP.
+	// If true, serve HTTPS instead of HTTP (tsnet).
 	ServeHTTPS bool `json:"serveHTTPS,omitempty"`
 
 	// If non-empty, a SQLite database URL to use for local state.

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -634,7 +634,7 @@ func DefaultCheckQuery(q Query) (Query, error) {
 type Queryable interface {
 	// Query issues the specified SQL query in a transaction and returns the
 	// matching result set, if any.
-	Query(ctx context.Context, sql string) (RowSet, error)
+	Query(ctx context.Context, sql string, params ...any) (RowSet, error)
 
 	// Close closes the database.
 	Close() error
@@ -665,6 +665,6 @@ type RowSet interface {
 
 type sqlDB struct{ *sql.DB }
 
-func (s sqlDB) Query(ctx context.Context, query string) (RowSet, error) {
-	return s.DB.QueryContext(ctx, query)
+func (s sqlDB) Query(ctx context.Context, query string, params ...any) (RowSet, error) {
+	return s.DB.QueryContext(ctx, query, params...)
 }

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -664,3 +664,14 @@ type RowSet interface {
 	// pointed to by its arguments.
 	Scan(...any) error
 }
+
+type sqlDB struct{ *sql.DB }
+
+func (s sqlDB) Query(ctx context.Context, query string) (RowSet, error) {
+	tx, err := s.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback()
+	return tx.QueryContext(ctx, query)
+}

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -520,27 +520,31 @@ func (d *Duration) UnmarshalText(data []byte) error {
 }
 
 // A DBSpec describes a database that the server should use.
+//
+// The Source must be non-empty, and exactly one of URL, KeyFile, Secret, or DB
+// must be set.
+//
+//   - If DB is set, it is used directly as the database to query, and no
+//     connection is established.
+//
+// Otherwise, the Driver must be non-empty and the [database/sql] library is
+// used to open a connection to the specified database:
+//
+//   - If URL is set, it is used directly as the connection string.
+//
+//   - If KeyFile is set, it names the location of a file containing the
+//     connection string.  If set, KeyFile is expanded by os.ExpandEnv.
+//
+//   - Otherwise, Secret is the name of a secret to fetch from the secrets
+//     service, whose value is the connection string. This requires that a
+//     secrets server be configured in the options.
 type DBSpec struct {
-	Source string `json:"source"`           // UI slug
+	Source string `json:"source"`           // UI slug (required)
 	Label  string `json:"label,omitempty"`  // descriptive label
 	Driver string `json:"driver,omitempty"` // e.g., "sqlite", "snowflake"
 
 	// Named is an optional map of named SQL queries the database should expose.
 	Named map[string]string `json:"named,omitempty"`
-
-	// Exactly one of the following fields must be set.
-	//
-	// If URL is set, it is used directly as the connection string.
-	//
-	// If KeyFile is set, it names the location of a file containing the
-	// connection string.  If set, KeyFile is expanded by os.ExpandEnv.
-	//
-	// If DB is set, it is used directly as the database to query, and no
-	// connection is established.
-	//
-	// Otherwise, Secret is the name of a secret to fetch from the secrets
-	// service, whose value is the connection string. This requires that a
-	// secrets server be configured in the options.
 
 	URL     string    `json:"url,omitempty"`     // path or connection URL
 	KeyFile string    `json:"keyFile,omitempty"` // path to key file

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -542,6 +542,8 @@ type DBSpec struct {
 	// Named is an optional map of named SQL queries the database should expose.
 	Named map[string]string `json:"named,omitempty"`
 
+	// Exactly one of the fields below must be set.
+
 	URL     string    `json:"url,omitempty"`     // path or connection URL
 	KeyFile string    `json:"keyFile,omitempty"` // path to key file
 	Secret  string    `json:"secret,omitempty"`  // name of secret

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -567,7 +567,7 @@ func (d *DBSpec) checkValid() error {
 	// Case 1: A programmatic data source.
 	if d.DB != nil {
 		if d.countFields() != 0 {
-			return errors.New("exactly one connection source must be set")
+			return errors.New("no connection string is allowed when DB is set")
 		}
 		return nil
 	}

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -211,14 +211,6 @@ func (o Options) localState() (*localState, error) {
 	return newLocalState(db)
 }
 
-func (o Options) readOnlyLocalState() (*sql.DB, error) {
-	if o.LocalState == "" {
-		return nil, errors.New("no local state")
-	}
-	url := "file:" + os.ExpandEnv(o.LocalState) + "?mode=ro"
-	return sql.Open("sqlite", url)
-}
-
 func (o Options) logf() logger.Logf {
 	if o.Logf == nil {
 		return log.Printf

--- a/server/tailsql/tailsql.go
+++ b/server/tailsql/tailsql.go
@@ -142,14 +142,10 @@ func NewServer(opts Options) (*Server, error) {
 		return nil, fmt.Errorf("local state: %w", err)
 	}
 	if state != nil && opts.LocalSource != "" {
-		db, err := opts.readOnlyLocalState()
-		if err != nil {
-			return nil, fmt.Errorf("read-only local state: %w", err)
-		}
 		dbs = append(dbs, &dbHandle{
 			src:   opts.LocalSource,
 			label: "tailsql local state",
-			db:    sqlDB{DB: db},
+			db:    state,
 			named: map[string]string{
 				"schema": `select * from sqlite_schema`,
 			},

--- a/server/tailsql/tailsql.go
+++ b/server/tailsql/tailsql.go
@@ -467,13 +467,11 @@ func (s *Server) queryContext(ctx context.Context, caller string, q Query) (*dbR
 			}
 			defer rows.Close()
 
-			cols, err := rows.ColumnTypes()
+			cols, err := rows.Columns()
 			if err != nil {
-				return nil, fmt.Errorf("listing column types: %w", err)
+				return nil, fmt.Errorf("listing column names: %w", err)
 			}
-			for _, col := range cols {
-				out.Columns = append(out.Columns, col.Name())
-			}
+			out.Columns = cols
 
 			var tooMany bool
 			for rows.Next() && !tooMany {

--- a/server/tailsql/tailsql_test.go
+++ b/server/tailsql/tailsql_test.go
@@ -521,6 +521,6 @@ func TestQueryable(t *testing.T) {
 
 type sqlDB struct{ *sql.DB }
 
-func (s sqlDB) Query(ctx context.Context, query string) (tailsql.RowSet, error) {
-	return s.DB.QueryContext(ctx, query)
+func (s sqlDB) Query(ctx context.Context, query string, params ...any) (tailsql.RowSet, error) {
+	return s.DB.QueryContext(ctx, query, params...)
 }

--- a/server/tailsql/utils.go
+++ b/server/tailsql/utils.go
@@ -5,7 +5,6 @@ package tailsql
 
 import (
 	"context"
-	"database/sql"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -148,12 +147,12 @@ func isBinaryData(data []byte) bool {
 	return false
 }
 
-// runQueryInTx executes query using h.Tx, and returns its results.
-func runQueryInTx[T any](ctx context.Context, h *dbHandle, query func(context.Context, *sql.Tx) (T, error)) (T, error) {
+// runQuery executes query using h.WithLock, and returns its results.
+func runQuery[T any](ctx context.Context, h *dbHandle, run func(context.Context, Queryable) (T, error)) (T, error) {
 	var out T
-	err := h.Tx(ctx, func(fctx context.Context, tx *sql.Tx) error {
+	err := h.WithLock(ctx, func(fctx context.Context, q Queryable) error {
 		var err error
-		out, err = query(fctx, tx)
+		out, err = run(fctx, q)
 		return err
 	})
 


### PR DESCRIPTION
Allow a caller to hook up databases that do not require use of the database/sql package directly.

The substance of the change is to add Queryable and RowSet interfaces, and to rework the query plumbing to use them. Existing use of *sql.DB is shimmed with a wrapper implementing Queryable.

I was going to use a generic interface so that a shim would not be needed, but this turned out to be more trouble than it was worth, since it infects the rest of the package with type parameters. It was (much) simpler to use the wrapper.
