### PR TITLE
server: add a RoutePrefix option

### DIFF
--- a/cmd/tailsql/tailsql.go
+++ b/cmd/tailsql/tailsql.go
@@ -124,7 +124,7 @@ func runLocalService(ctx context.Context, opts tailsql.Options, port int) error 
 		hsrv.Shutdown(context.Background()) // ctx is already terminated
 		tsql.Close()
 	}()
-	log.Printf("Starting local tailsql at http://%s", hsrv.Addr)
+	log.Printf("Starting local tailsql at http://%s", hsrv.Addr+opts.RoutePrefix)
 	if err := hsrv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
 		ctrl.Fatalf(err.Error())
 	}

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -52,6 +52,10 @@ type Options struct {
 	// Additional links that should be propagated to the UI.
 	UILinks []UILink `json:"links,omitempty"`
 
+	// If set, prepend this prefix to each HTTP route. By default, routes are
+	// anchored at "/".
+	RoutePrefix string `json:"routePrefix,omitempty"`
+
 	// The maximum timeout for a database query (0 means no timeout).
 	QueryTimeout Duration `json:"queryTimeout,omitempty"`
 
@@ -209,6 +213,15 @@ func (o Options) localState() (*localState, error) {
 		return nil, fmt.Errorf("ping %q: %w", url, err)
 	}
 	return newLocalState(db)
+}
+
+func (o Options) routePrefix() string {
+	if o.RoutePrefix != "" {
+		// Routes are anchored at "/" by default, so remove a trailing "/" if
+		// there is one. E.g., "/foo/" beomes "/foo", and "/" becomes "".
+		return strings.TrimSuffix(o.RoutePrefix, "/")
+	}
+	return ""
 }
 
 func (o Options) logf() logger.Logf {

--- a/server/tailsql/static/script.js
+++ b/server/tailsql/static/script.js
@@ -6,7 +6,7 @@ import { Params, Area, Cycle, Loop } from './sprite.js';
     const dlButton = document.getElementById("dl-button");
     const qform    = document.getElementById('qform');
     const output   = document.getElementById('output');
-    const origin   = document.location.origin;
+    const base     = document.location.origin + document.location.pathname;
     const sources  = document.getElementById('sources');
     const body     = document.getElementById('tsql');
 
@@ -100,8 +100,8 @@ import { Params, Area, Cycle, Loop } from './sprite.js';
     dlButton.addEventListener("click", (evt) => {
         var fd = new FormData(qform);
         var sp = new URLSearchParams(fd);
+        var href = base + "csv?" + sp.toString();
 
-        var href = origin + "/csv?" + sp.toString();
         performDownload('query.csv', href);
     });
 

--- a/server/tailsql/static/style.css
+++ b/server/tailsql/static/style.css
@@ -186,7 +186,7 @@ div.action {
 .action .ctrl:before {
   display: none;
 }
-.action .ctrl:-webkit-details-marker {
+.action .ctrl::-webkit-details-marker {
   display: none;
 }
 
@@ -195,6 +195,6 @@ div.action {
   position: relative;
   height: 32px;
   width: 32px;
-  background: url('/static/nut.png') 0px 0px;
+  background: url('nut.png') 0px 0px;
   visibility: hidden;
 }

--- a/server/tailsql/ui.tmpl
+++ b/server/tailsql/ui.tmpl
@@ -2,12 +2,12 @@
 <html><head>
  <title>Tailscale SQL Playground</title>
  <meta charset="utf-8" />
- <link rel="stylesheet" type="text/css" href="/static/style.css" />
- <link rel="icon" href="/static/favicon.ico" />
+ <link rel="stylesheet" type="text/css" href="{{.RoutePrefix}}/static/style.css" />
+ <link rel="icon" href="{{.RoutePrefix}}/static/favicon.ico" />
 </head><body id="tsql">
 
 <div class="logo">
-  <img src="/static/logo.svg" width=64 height=64 />
+  <img src="{{.RoutePrefix}}/static/logo.svg" width=64 height=64 />
   <span>TailSQL</span>
 </div>
 
@@ -56,6 +56,6 @@
 </table></div>
 {{end -}}
 
-<script type="module" src="/static/script.js"></script>
+<script type="module" src="{{.RoutePrefix}}/static/script.js"></script>
 </body>
 </html>

--- a/server/tailsql/utils.go
+++ b/server/tailsql/utils.go
@@ -30,12 +30,13 @@ type LocalClient interface {
 
 // uiData is the concrete type of the data value passed to the UI template.
 type uiData struct {
-	Query   string      // the original query
-	Sources []*dbHandle // the available databases
-	Source  string      // the selected source
-	Output  *dbResult   // query results (may be nil)
-	Error   *string     // error results (may be nil)
-	Links   []UILink    // static UI links
+	Query       string      // the original query
+	Sources     []*dbHandle // the available databases
+	Source      string      // the selected source
+	Output      *dbResult   // query results (may be nil)
+	Error       *string     // error results (may be nil)
+	Links       []UILink    // static UI links
+	RoutePrefix string      // for links to the API and static files
 }
 
 // Version reports the version string of the currently running binary.


### PR DESCRIPTION
In some cases it is useful to run TailSQL on a server that already has other
endpoints. To support this, add a RoutePrefix option: When this is set, it will
be prepended to the the UI, API, and static file routes handled by the tailsql
server.

- Add tests to exercise prefixed routes.
- Plumb the prefix into the UI template and use it for static files.
- Fix an absolute path in the style sheet.
- Fix an absolute path in the CSV download script.
- Log a prefixed route in the example CLI.
