### PR TITLE
server: disallow VACUUM in SQL statements

### DIFF
--- a/server/tailsql/internal_test.go
+++ b/server/tailsql/internal_test.go
@@ -31,11 +31,14 @@ func TestCheckQuerySyntax(t *testing.T) {
 		// Basic disallowed stuff.
 		{`ATTACH DATABASE "foo" AS bar;`, false},
 		{`DETACH DATABASE bar;`, false},
+		{`VACUUM`, false},
+		{`VACUUM INTO '/dev/null';`, false},
 
 		// Things that should not be disallowed despite looking sus.
 		{`SELECT 'ATTACH DATABASE "foo" AS bar;' FROM hell;`, true},
 		{`-- attach database not really
         select * from a join b using (uid); -- ok  `, true},
+		{`-- vacuum into 'hell'`, true},
 
 		// Things that should be disallowed despite being sneaky.
 		{` -- hide me

--- a/server/tailsql/utils.go
+++ b/server/tailsql/utils.go
@@ -217,11 +217,12 @@ func errorCode(err error) int {
 // A read-only SQLite database will correctly report errors for operations that
 // modify the database or its schema if it is opened read-only. However, the
 // ATTACH and DETACH verbs modify only the connection, permitting the caller to
-// mention any database accessible from the filesystem.
+// mention any database accessible from the filesystem. Similarly, VACUUM INTO
+// can be run even on a read-only database, so don't allow it in any form.
 func checkQuerySyntax(query string) error {
 	for _, tok := range sqlTokens(query) {
 		switch tok {
-		case "ATTACH", "DETACH", "TEMP", "TEMPORARY":
+		case "ATTACH", "DETACH", "TEMP", "TEMPORARY", "VACUUM":
 			return fmt.Errorf("statement %q is not allowed", tok)
 		}
 	}


### PR DESCRIPTION
Although SQLite does not permit VACUUM on a read-only database, it does allow a
VACUUM INTO targeting a different file. Rule that out.
