### PR TITLE
server: restore separate connections for the local state db

### DIFF
--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -205,14 +205,7 @@ func (o Options) localState() (*localState, error) {
 		return nil, nil
 	}
 	url := os.ExpandEnv(o.LocalState)
-	db, err := sql.Open("sqlite", url)
-	if err != nil {
-		return nil, fmt.Errorf("open %q: %w", url, err)
-	} else if err := db.PingContext(context.Background()); err != nil {
-		db.Close()
-		return nil, fmt.Errorf("ping %q: %w", url, err)
-	}
-	return newLocalState(db)
+	return newLocalState(url)
 }
 
 func (o Options) routePrefix() string {


### PR DESCRIPTION
In #25 I switched away from using a transaction for queries on the local state
database, because it did not interact properly with the queryable interface we
added in #24. But because I'd switched away from having a separate read-only
connection for these queries, this had the undesirable side-effect of allowing
write queries on the local state database.

Switch back to using a separate read-only connection for local state.  Morally
this is a partial revert of #24, but done in a slightly different way.
