### PR TITLE
server/tailsql: make ControlURL configurable

### DIFF
--- a/cmd/tailsql/tailsql.go
+++ b/cmd/tailsql/tailsql.go
@@ -128,9 +128,10 @@ func runLocalService(ctx context.Context, opts tailsql.Options, port int) error 
 
 func runTailscaleService(ctx context.Context, opts tailsql.Options) error {
 	tsNode := &tsnet.Server{
-		Dir:      os.ExpandEnv(opts.StateDir),
-		Hostname: opts.Hostname,
-		Logf:     logger.Discard,
+		Dir:        os.ExpandEnv(opts.StateDir),
+		Hostname:   opts.Hostname,
+		ControlURL: opts.ControlURL,
+		Logf:       logger.Discard,
 	}
 	if flags.DebugLog {
 		tsNode.Logf = log.Printf

--- a/server/tailsql/options.go
+++ b/server/tailsql/options.go
@@ -39,6 +39,10 @@ type Options struct {
 	// If true, serve HTTPS instead of HTTP (tsnet).
 	ServeHTTPS bool `json:"serveHTTPS,omitempty"`
 
+	// The URL of the coordination server to use (tsnet).
+	// If empty, the Tailscale default is used.
+	ControlURL string `json:"controlURL,omitempty"`
+
 	// If non-empty, a SQLite database URL to use for local state.
 	LocalState string `json:"localState,omitempty"`
 


### PR DESCRIPTION
Add the ability to use an alternative control server (e.g. Headscale).