### PR TITLE
server/tailsql: associate saved queries with a source

### DIFF
--- a/server/tailsql/static/script.js
+++ b/server/tailsql/static/script.js
@@ -136,6 +136,12 @@ import { Params, Area, Cycle, Loop } from './sprite.js';
         const h = getHistory();
         for (const entry of h) {
             const li = document.createElement('li');
+            if (entry.source) {
+                const src = document.createElement('span');
+                src.className = 'query-source';
+                src.textContent = entry.source;
+                li.appendChild(src);
+            }
             const span = document.createElement('span');
             span.className = 'query-text';
             span.textContent = entry.query;
@@ -163,6 +169,12 @@ import { Params, Area, Cycle, Loop } from './sprite.js';
         for (let i = 0; i < s.length; i++) {
             const entry = s[i];
             const li = document.createElement('li');
+            if (entry.source) {
+                const src = document.createElement('span');
+                src.className = 'query-source';
+                src.textContent = entry.source;
+                li.appendChild(src);
+            }
             const name = document.createElement('span');
             name.className = 'query-name';
             name.textContent = entry.name + ':';
@@ -186,6 +198,14 @@ import { Params, Area, Cycle, Loop } from './sprite.js';
             li.appendChild(del);
             li.addEventListener('click', () => {
                 query.value = entry.query;
+                if (sources && entry.source) {
+                    for (const opt of sources.options) {
+                        if (opt.value === entry.source) {
+                            opt.selected = true;
+                            break;
+                        }
+                    }
+                }
                 query.focus();
             });
             savedList.appendChild(li);
@@ -210,7 +230,7 @@ import { Params, Area, Cycle, Loop } from './sprite.js';
         const name = prompt('Name for this query:');
         if (!name) return;
         const s = getSavedQueries();
-        s.push({ query: q, name: name.trim() });
+        s.push({ query: q, name: name.trim(), source: sources.value });
         setSavedQueries(s);
         renderSavedQueries();
     });

--- a/server/tailsql/static/style.css
+++ b/server/tailsql/static/style.css
@@ -244,6 +244,11 @@ div.action {
   color: var(--text-light);
   padding: 0 0.2rem;
 }
+#query-panels li .query-source {
+  flex: 0 0 auto;
+  color: var(--text-light);
+  font-size: 90%;
+}
 #query-panels li .query-name {
   font-family: var(--body-font);
   font-weight: 600;


### PR DESCRIPTION
Associates saves queries (and history) with only one source. Shows the source in the list explicitly. When clicking on a saved query or query from history, the source is automatically changed to that of the query.

<img width="1348" height="470" alt="Screenshot 2026-05-22 at 9 47 17 AM" src="https://github.com/user-attachments/assets/077fa59b-ddb3-482f-8054-28c95e688dbe" />
