### PR TITLE
server/tailsql/static: use tabular nums in tailsql results table

### DIFF
--- a/server/tailsql/static/style.css
+++ b/server/tailsql/static/style.css
@@ -84,6 +84,8 @@ div.error {
 .output table  {
   min-width: 25%;
   border-spacing: 1px;
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: 'tnum';
 }
 .output td, .output th {
   border: 1px dotted var(--cell-border);


### PR DESCRIPTION
This ensures that each numeric character in the results table has a fixed width, making it slightly easier to parse rows upon rows of numbers.

Updates tailscale/corp#45965