### PR TITLE
server,uirules: align number-shaped values on the right in UI output

### DIFF
--- a/cmd/tailsql/tailsql.go
+++ b/cmd/tailsql/tailsql.go
@@ -78,6 +78,7 @@ with defaults suitable for running a local service and then exits.`,
 			opts.Metrics = expvar.NewMap("tailsql")
 			opts.UIRewriteRules = []tailsql.UIRewriteRule{
 				uirules.FormatSQLSource,
+				uirules.WrapNumber,
 				uirules.FormatJSONText,
 				uirules.LinkURLText,
 			}

--- a/server/tailsql/static/style.css
+++ b/server/tailsql/static/style.css
@@ -98,6 +98,9 @@ div.error {
   background: var(--bg-colname);
   border-style: solid;
 }
+.output td:has(span.number) {
+  text-align: right;
+}
 
 .logo {
   display: flex;

--- a/uirules/uirules.go
+++ b/uirules/uirules.go
@@ -71,3 +71,13 @@ var LinkURLText = tailsql.UIRewriteRule{
 		return s
 	},
 }
+
+// WrapNumber is a UI rewrite rule that wraps "number-shaped" values in a span
+// with the "number" class, to allow special styling to apply.
+var WrapNumber = tailsql.UIRewriteRule{
+	Value: regexp.MustCompile(`^-?\d+(?:\.\d*)?(?:[eE][-+]?\d+)?$`),
+	Apply: func(col, s string, _ []string) any {
+		esc := template.HTMLEscapeString(s)
+		return template.HTML(fmt.Sprintf(`<span class=number>%s</span>`, esc))
+	},
+}

--- a/uirules/uirules_test.go
+++ b/uirules/uirules_test.go
@@ -50,6 +50,13 @@ func TestRules(t *testing.T) {
 		{uirules.LinkURLText, "http://localhost:8080/foo?bar", true,
 			template.HTML(`<a href="http://localhost:8080/foo?bar" referrerpolicy=no-referrer ` +
 				`rel=noopener>http://localhost:8080/foo?bar</a>`)},
+
+		{uirules.WrapNumber, "12345", true, template.HTML(`<span class=number>12345</span>`)},
+		{uirules.WrapNumber, "1.abc", false, nil},
+		{uirules.WrapNumber, "-101", true, template.HTML(`<span class=number>-101</span>`)},
+		{uirules.WrapNumber, "9e72", true, template.HTML(`<span class=number>9e72</span>`)},
+		{uirules.WrapNumber, "0.5432", true, template.HTML(`<span class=number>0.5432</span>`)},
+		{uirules.WrapNumber, "-101.95E-99", true, template.HTML(`<span class=number>-101.95E-99</span>`)},
 	}
 	for _, tc := range tests {
 		ok, got := tc.rule.CheckApply("colName", tc.input)


### PR DESCRIPTION
Demo:

```shell
go run ./cmd/tailsql --init-config demo.json

sqlite3 test.db <<EOF
create table example (a integer, b integer, c text);
insert into example (a, b, c)
values (1, 2, 'apple'), (34, 567, 'pear'), (98765.43, 0, 'plum'), (1033.9, 593, 'cherry');
EOF

go run ./cmd/tailsql --config demo.json --local 8080
```

Visit the UI at http://localhost:8080/?q=select+*+from+example&src=main
